### PR TITLE
Remove fairseq and uroman dependencies (no cloning anymore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ datasets/moore
 steps.md
 uroman/
 fairseq/
+venv/
+pipelines_proverbes_2.sh
 tutorials/cleaning.ipynb
 tutorials/merging.ipynb
 tutorials/STEPS_BIBLE_DATASET_CREATION.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,17 @@ steps.md
 uroman/
 fairseq/
 tutorials/cleaning.ipynb
+tutorials/merging.ipynb
 tutorials/STEPS_BIBLE_DATASET_CREATION.md
 ./pipelines_proverbes_2.sh
+crawlers/youtube/youtube_scraper.py
+data_export/reverse_hf_to_raw.py
+data_export/reverse_pipeline.sh
+tutorials/temp_cleaning.ipynb
+tutorials/youtube_scraper.py
+preprocessing/sanitize_folder.sh
+preprocessing/convert_audio_to_wav.py
+preprocessing/count_audio_files.py
 
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue)](https://www.python.org/downloads/release/python-3100/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-Modular tools to collect, preprocess, align, and prepare Mooré speech/text data for **Text-to-Speech (TTS)** and **Automatic Speech Recognition (ASR)**.
+A complete toolkit for building Mooré speech datasets. Collect, preprocess, align, and export high-quality audio/text pairs for **Text-to-Speech (TTS)** and **Automatic Speech Recognition (ASR)**.
 
 This toolkit reproduces the full [Moore Speech Corpora](https://huggingface.co/datasets/anyantudre/MooreSpeechCorpora) data collection pipeline.
 
@@ -10,11 +10,11 @@ This toolkit reproduces the full [Moore Speech Corpora](https://huggingface.co/d
 
 ## Table of Contents
 1. [Features](#features)  
-2. [Installation](#installation)  
+2. [Installation & Setup](#installation--setup)  
 3. [Quick Start](#quick-start)  
-4. [Usage](#usage)
-5. [Contributing](#contributing)  
-6. [License](#license)
+4. [Contributing](#contributing)  
+5. [Contacts & Citation](#contacts--citation)
+6. [Acknowledgments](#acknowledgments)
 
 ---
 
@@ -32,12 +32,12 @@ The toolkit is structured as follows:
 moore-toolkit/
 ├─ crawlers/             # Bible, YouTube, etc.
 ├─ preprocessing/        # Resample, normalize text
-├─ forced_alignment/     # MMS scripts & wrappers
-├─ datasets/             # HF dataset prep & push
-├─ utils/                # Shared helpers
+├─ forced_alignement/    # MMS scripts & data_prep tools
+├─ uroman_tools/         # Romanization tools (extracted)
+├─ data_export/          # HF dataset prep & push
 ├─ environment.yml
 └─ README.md
-````
+```
 
 ---
 
@@ -82,10 +82,10 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder datasets/moore/bible/resampled \
   --output_folder datasets/moore/bible/aligned \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman_tools/bin
 ```
 
-See [forced\_alignment/README.md](forced_alignment/README.md) for full instructions and more details.
+See [forced_alignement/README.md](forced_alignement/README.md) for full instructions and more details.
 
 * **Dataset Preparation/Export:** uploads dataset with columns: audio, transcription, duration, chapter to Hugging Face Hub.
 
@@ -117,9 +117,34 @@ Contributions are more than welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.
 
 ---
 
+## Contacts & Citation
+
+**Curator:**
+- [Wendyellé A. Alban NYANTUDRE](https://github.com/anyantudre) (@anyantudre)
+- [Aristide BANDAOGO](https://github.com/Bandoss-Ariss) (@Bandoss-Ariss)
+
+**Example Citation:**
+```bibtex
+@misc{anyantudre2025moorespeechcorpora,
+  title        = {Moore Speech Corpora: Toolkit to collect, preprocess, align, and prepare Mooré speech/text data for TTS and ASR.},
+  author       = {Nyantudre, Wendyellé Abubakrh Alban and Bandaogo, Aristide},
+  year         = {2025},
+  howpublished = {Available at \url{https://github.com/anyantudre/MooreSpeechCorpora}},
+  note         = {GO AI Corporation}
+}
+```
+
+**License Compliance:**
+This work builds on several open-source components. When using this toolkit or derived datasets, please:
+- Credit this work using proper citation
+- Comply with all original component licenses (see Acknowledgments)
+- Include appropriate attribution in publications and derived works
+
+---
+
 ## Acknowledgments
 * [cawoylel](https://github.com/cawoylel/): this repo is largely inspired by their excellent work on the Fula language!
-* [Facebook AI Research Fairseq](https://github.com/facebookresearch/fairseq/) for multilingual alignment tools.
+* [Facebook AI Research Fairseq](https://github.com/facebookresearch/fairseq/) for the original MMS alignment tools (adapted in `forced_alignement/data_prep/`).
 * [bible.com](https://www.bible.com/) for Mooré audio/text
-* [Uroman](https://github.com/isi-nlp/uroman) for romanization
+* [Uroman](https://github.com/isi-nlp/uroman) for romanization (tools included in `uroman_tools/`)
 * [Resemble Enhance](https://github.com/resemble-ai/resemble-enhance) for speech enhancement

--- a/crawlers/__init__.py
+++ b/crawlers/__init__.py
@@ -1,0 +1,1 @@
+"""Module for crawling data from various sources."""

--- a/crawlers/contes_website/contes_scraper.py
+++ b/crawlers/contes_website/contes_scraper.py
@@ -1,5 +1,5 @@
 """
-Contes Crawler from https://mooreburkina.com/fr/sitemap
+Contes Crawler for https://mooreburkina.com/fr/sitemap
 Author: @anyantudre
 """
 

--- a/crawlers/proverbes_website/crawl.sh
+++ b/crawlers/proverbes_website/crawl.sh
@@ -30,7 +30,7 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder datasets/moore/proverbes_moore/vol2/resampled \
   --output_folder datasets/moore/proverbes_moore/vol2/aligned \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman_tools/bin
 
 python datasets/prepare_proverbes_dataset.py \
   --input_folder datasets/moore/proverbes_moore/vol2/aligned \

--- a/crawlers/proverbes_website/proverbes_scraper.py
+++ b/crawlers/proverbes_website/proverbes_scraper.py
@@ -1,5 +1,5 @@
 """
-proverbes Crawler from https://mooreburkina.com/fr/sitemap
+proverbes Crawler for https://mooreburkina.com/fr/sitemap
 Author: @anyantudre
 """
 

--- a/data_export/README.md
+++ b/data_export/README.md
@@ -1,12 +1,12 @@
 # Data Folder
 Scripts to convert aligned audio-text data into Hugging Face Dataset format ready for ASR/TTS tasks.
 
-It is a placeholder, intended for storing raw and processed data files.
-
 
 ### Structure
 - `prepare_hf_dataset.py`: generates and pushes a HF dataset from aligned folder structures.
 - `prepare_proverbes_dataset.py`: specialized script for proverbes with Moore-French paired structure.
+- `reverse_hf_to_raw.py`: **reverse pipeline** - converts HF dataset back to raw format for manual correction.
+- `reverse_pipeline.sh`: **complete reverse workflow** - automated script for the full correction pipeline.
 - `raw/`: raw downloaded audio and text files.
 - `aligned/`: forced-aligned audio-text segments ready for dataset creation.
 
@@ -33,5 +33,28 @@ Or omit --hf_token if you've already run:
 ```bash
 huggingface-cli login
 ```
+
+**For reverse pipeline (HF dataset → raw format):**
+```bash
+python data_export/reverse_hf_to_raw.py \
+  --dataset_id your-username/your-dataset \
+  --output_folder datasets/corrected/raw \
+  --split train \
+  --organize_by_speaker
+```
+
+This converts a HF dataset with columns `(audio, text, duration, voice, speaker_id)` back to raw format with `.wav` and `.txt` files for manual correction and re-alignment. After manual corrections, you can run the standard pipeline:
+
+1. **Resample**: `bash preprocessing/resample.sh --input_folder datasets/corrected/raw --output_folder datasets/corrected/resampled`
+2. **Align**: `bash forced_alignement/align_and_segment.sh --audio_folder datasets/corrected/resampled --text_folder datasets/corrected/resampled --output_folder datasets/corrected/aligned --lang mos`
+3. **Export**: `python data_export/prepare_hf_dataset.py --input_folder datasets/corrected/aligned --repo_id your-corrected-dataset`
+
+**Or use the complete automated workflow:**
+```bash
+bash data_export/reverse_pipeline.sh \
+  --dataset_id your-username/your-dataset \
+  --output_base datasets/corrected
+```
+This script handles the entire reverse pipeline with manual correction prompts.
 
 **Note:** It is recommended to add this folder to `.gitignore` to avoid pushing large data files (Not this one anymore but `datasets` folder).

--- a/data_export/prepare_hf_dataset.py
+++ b/data_export/prepare_hf_dataset.py
@@ -7,29 +7,61 @@ from datasets import Dataset
 import datasets
 
 
+def get_first_sentence(text):
+    """Extract only the first sentence (before first period)"""
+    first_sentence = text.split('.')[0].strip()
+    return first_sentence + '.' if first_sentence else text
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Upload aligned audio dataset to Hugging Face Hub")
     parser.add_argument("--input_folder", required=True, help="Path to aligned chapter folders")
     parser.add_argument("--repo_id", required=True, help="Hugging Face repo ID to upload to")
     parser.add_argument("--split", required=False, default="train", help="Dataset split name (default: train)")
     parser.add_argument("--hf_token", required=False, help="Optional HF token (if not already logged in)")
+    parser.add_argument("--remove_duplicates", action="store_true", help="Keep only the first sentence in transcription")
     return parser.parse_args()
 
-def dataset_generator(input_folder: Path):
+def dataset_generator(input_folder: Path, remove_duplicates=False):
+    #tokens to filter out (noise/music segments)
+    filter_tokens = {"silence", "<star>"}
+    
     for chapter_dir in sorted(input_folder.glob("*/")):
         manifest_path = chapter_dir / "manifest.json"
         if not manifest_path.exists():
             continue
+            
+        # Extract metadata from folder name (format: idx_speaker_id_voice)
+        folder_parts = chapter_dir.name.split('_')
+        if len(folder_parts) >= 3:
+            speaker_id = folder_parts[1] 
+            voice = folder_parts[2]
+        else:
+            # Fallback for other naming formats
+            speaker_id = "unknown"
+            voice = "unknown"
+            
         with open(manifest_path, "r", encoding="utf-8") as f:
             for line in f:
                 entry = json.loads(line.strip())
+                
+                #skip noise/music segments
+                if entry["normalized_text"].strip() in filter_tokens:
+                    continue
+                
+                transcription = entry["normalized_text"]
+                if remove_duplicates:
+                    transcription = get_first_sentence(transcription)
+                    
                 audio_fp = entry["audio_filepath"]
                 if audio_fp.startswith("../"):
                     audio_fp = audio_fp[3:]
                 yield {
                     "audio": audio_fp,
-                    "transcription": entry["text"],
+                    "transcription": transcription,
                     "duration": round(entry["duration"], 2),
+                    "voice": voice,
+                    "speaker_id": speaker_id,
                     "chapter": chapter_dir.name
                 }
 
@@ -49,21 +81,35 @@ def main():
         "audio": datasets.features.Audio(sampling_rate=16_000),
         "transcription": datasets.Value("string"),
         "duration": datasets.Value("float"),
+        "voice": datasets.Value("string"),
+        "speaker_id": datasets.Value("string"),
         "chapter": datasets.Value("string"),
     })
 
-    examples = list(dataset_generator(input_path))
+    examples = list(dataset_generator(input_path, args.remove_duplicates))
     if not examples:
         print(f"Error: no examples found under '{args.input_folder}'. Check your path and folder structure.", file=sys.stderr)
         sys.exit(1)
 
     print(f"Loaded {len(examples)} examples")
+    if args.remove_duplicates:
+        print("✂️ Applied first sentence extraction")
 
     total_duration_sec = sum(x["duration"] for x in examples)
     total_hours = total_duration_sec / 3600
 
     dataset = Dataset.from_list(examples, features=features).cast_column("audio", datasets.Audio())
     dataset.push_to_hub(args.repo_id, split=args.split, private=True)
+
+    # #save locally
+    # local_path = f"datasets/hf_cache/{args.repo_id.replace('/', '_')}"
+    # print(f"💾 Saving dataset locally to {local_path}...")
+    # dataset.save_to_disk(local_path)
+    
+    # #push to hub
+    # print(f"📤 Loading and uploading dataset to {args.repo_id}...")
+    # local_dataset = Dataset.load_from_disk(local_path)
+    # local_dataset.push_to_hub(args.repo_id, split=args.split, private=True)
 
     print(f"✅ Successfully pushed to https://huggingface.co/datasets/{args.repo_id}")
     print(f"🎉 Total audio duration: {total_hours:.2f} hours")

--- a/forced_alignement/README.md
+++ b/forced_alignement/README.md
@@ -1,14 +1,25 @@
 # Forced Alignment
-Scripts to perform forced alignment and segmentation of audio-text pairs using Fairseq MMS tools.
+Scripts to perform forced alignment and segmentation of audio-text pairs using MMS tools.
 
-### Requirements
-- Fairseq installed with MMS examples.
-- Uroman tool for romanization (see README at repo root for setup).
+## Requirements
+- `torchaudio` with MMS model support
+- `sox` for audio processing
+- `perl` for uroman text romanization (tools included)
 
-### Usage
+## Components
+- `data_prep/`: MMS alignment tools (adapted from fairseq)
+- `align_and_segment.sh`: Main alignment script
+
+## Usage
 ```bash
-bash align_and_segment.sh [audio_folder] [text_folder] [output_folder] [lang_code] [uroman_path]
+bash forced_alignement/align_and_segment.sh \
+  --audio_folder <audio_folder> \
+  --text_folder <text_folder> \
+  --output_folder <output_folder> \
+  --lang <language_code> \
+  --uroman_path <uroman_path>
 ```
+
 - Example Bible:
 ```bash
 bash forced_alignement/align_and_segment.sh \
@@ -16,7 +27,7 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder datasets/moore/bible/resampled \
   --output_folder datasets/moore/bible/aligned \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman/bin
 ```
 
 - Example Proverbes:
@@ -26,5 +37,5 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder datasets/moore/proverbes_moore/vol9/resampled \
   --output_folder datasets/moore/proverbes_moore/vol9/aligned \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman/bin
   ```

--- a/forced_alignement/align_and_segment.sh
+++ b/forced_alignement/align_and_segment.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-UROMAN_PATH="../uroman/bin"
+UROMAN_PATH="uroman_tools/bin"
 
 #parse named args
 while [[ "$#" -gt 0 ]]; do
@@ -25,23 +25,26 @@ fi
 
 mkdir -p "$OUTPUT_FOLDER"
 
-cd fairseq
-
-for wavpath in "../$AUDIO_FOLDER"/*.wav; do
+for wavpath in "$AUDIO_FOLDER"/*.wav; do
   filename="$(basename "$wavpath")"
   stem="${filename%.*}"
-  outdir="../$OUTPUT_FOLDER/$stem"
+  outdir="$OUTPUT_FOLDER/$stem"
+
+  # Skip if already processed
+  if [[ -d "$outdir" && -f "$outdir/manifest.json" ]]; then
+    echo "⏭️  Skipping $stem (already processed)"
+    continue
+  fi
 
   rm -rf "$outdir"
 
-  python -m examples.mms.data_prep.align_and_segment \
+  python forced_alignement/data_prep/align_and_segment.py \
     --audio_filepath "$wavpath" \
-    --text_filepath "../$TEXT_FOLDER/${stem}.txt" \
+    --text_filepath "$TEXT_FOLDER/${stem}.txt" \
     --lang "$LANG" \
     --outdir "$outdir" \
-    --uroman "$UROMAN_PATH"
+    --uroman_path "$UROMAN_PATH" \
+    --use_star
 
   echo "✅ Finished aligning $stem → $outdir"
 done
-
-cd ..

--- a/pipeline_proverbes.sh
+++ b/pipeline_proverbes.sh
@@ -62,7 +62,7 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder "$RESAMPLED_DIR" \
   --output_folder "$ALIGNED_DIR" \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman_tools/bin
 
 echo "☁️  Step 5/5: Pushing to HuggingFace..."
 HF_ARGS="--input_folder $ALIGNED_DIR --repo_id $REPO_ID --split $SPLIT"

--- a/pipelines_proverbes_2.sh
+++ b/pipelines_proverbes_2.sh
@@ -13,7 +13,7 @@
 #   --text_folder datasets/moore/proverbes_moore/vol9/resampled \
 #   --output_folder datasets/moore/proverbes_moore/vol9/aligned \
 #   --lang mos \
-#   --uroman_path ../uroman/bin
+#   --uroman_path uroman_tools/bin
 
 # python datasets/prepare_hf_dataset.py   --input_folder datasets/moore/proverbes_moore/vol9/aligned   --repo_id anyantudre/moore-speech-proverbes-2   --split "vol9"
 
@@ -73,7 +73,7 @@ bash forced_alignement/align_and_segment.sh \
   --text_folder "$RESAMPLED_DIR" \
   --output_folder "$ALIGNED_DIR" \
   --lang mos \
-  --uroman_path ../uroman/bin
+  --uroman_path uroman_tools/bin
 
 echo "☁️  Step 4/4: Pushing to HuggingFace..."
 HF_ARGS="--input_folder $ALIGNED_DIR --repo_id $REPO_ID --split $SPLIT"

--- a/preprocessing/resample.sh
+++ b/preprocessing/resample.sh
@@ -24,9 +24,10 @@ fi
 
 mkdir -p "$OUTPUT_FOLDER"
 
-for f in "$INPUT_FOLDER"/*.mp3; do
+for f in "$INPUT_FOLDER"/*.{mp3,wav}; do
+  [[ -f "$f" ]] || continue  # Skip if no files match
   filename="$(basename "$f")"
   stem="${filename%.*}"
   ffmpeg -y -nostdin -i "$f" -ac 1 -ar 16000 "$OUTPUT_FOLDER/${stem}.wav"
-  cp "$INPUT_FOLDER/${stem}.txt" "$OUTPUT_FOLDER/" 2>/dev/null
+  cp "$INPUT_FOLDER/${stem}.txt" "$OUTPUT_FOLDER/" 2>/dev/null || true
 done

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ icu-tokenizer==0.0.1
 sox==1.5.0
 librosa==0.11.0 
 datasets==3.6.0
+soundfile==0.12.1
 tensorboardX
 #ffmpeg-python #no need for now
 #fairseq #no need for now

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ datasets==3.6.0
 soundfile==0.12.1
 tensorboardX
 #ffmpeg-python #no need for now
-#fairseq #no need for now
+#fairseq #no need now


### PR DESCRIPTION
Here i tried to get rid of the necessity to clone the two repos needed for alignement which are respectively:
- [Facebook AI Research Fairseq](https://github.com/facebookresearch/fairseq/) for the original MMS alignment tools (adapted in `forced_alignement/data_prep/`) and 
- [Uroman](https://github.com/isi-nlp/uroman) for romanization (tools included in `uroman_tools/`)

I haven't tested yet this new setting but it should work seamlessly (i hope).